### PR TITLE
mention dependecies expected to be available as system commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ git clone --recursive https://github.com/opening-hours/opening_hours_map.git
 and install it’s dependencies (execute inside the repository):
 
 ```Shell
+sudo apt-get install jq
+npm install bower -g
+npm install uglify-js -g
 make dependencies-get
 ```
 


### PR DESCRIPTION
fixes #50, tested on Ubuntu 14.04 32bit
I am not entirely happy how it is formulated - apt-get for example is not really portable...