### PR TITLE
fix: use Referrer-Policy: strict-origin instead of no-referrer-when-downgrade

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
-        <meta name="referrer" content="no-referrer-when-downgrade">
+        <meta name="referrer" content="strict-origin">
         <title>Map with layer for the tag opening_hours based on OpenStreetMap</title>
         <link rel="icon" type="image/svg+xml" href="img/favicon.svg">
         <meta name="description" content="Interactive map showing opening_hours tags from OpenStreetMap with visual evaluation.">


### PR DESCRIPTION
`strict-origin` sends only scheme+host to OSM tile servers – sufficient to comply with the Tile Usage Policy, while also not sending anything on HTTPS→HTTP downgrades (unlike plain `origin`).

Ref: https://github.com/opening-hours/opening_hours_map/pull/73#issuecomment-4104843832

---

This PR was originally drafted with `origin`; switched to `strict-origin` based on a suggestion by @ypid.