### PR TITLE
fix: reverse geocode by lat/lon to avoid Nominatim 400 errors

### DIFF
--- a/js/init-modules.js
+++ b/js/init-modules.js
@@ -19,16 +19,17 @@ function josm(url_param) {
         });
 }
 
-// reverseGeocodeLocation function (adapted for compatibility with old callback-based API)
-window.reverseGeocodeLocation = function(query, on_success, on_error) {
-    const nominatim_api_url = 'https://nominatim.openstreetmap.org/reverse';
-    // Parse query parameters properly
-    let params = 'format=json&zoom=5&addressdetails=1&email=ypid23@aol.de';
-    if (query) {
-        // Remove leading & if present
-        params += query.startsWith('&') ? query : `&${query}`;
-    }
-    const nominatim_api_url_query = `${nominatim_api_url}?${params}`;
+// reverseGeocodeLocation: reverse geocode coordinates via Nominatim to get country/state context for opening_hours evaluation
+window.reverseGeocodeLocation = function(lat, lon, on_success, on_error) {
+    const params = new URLSearchParams({
+        format: 'json',
+        lat: String(lat),
+        lon: String(lon),
+        zoom: '5',
+        addressdetails: '1',
+        email: 'ypid23@aol.de',
+    });
+    const nominatim_api_url_query = `https://nominatim.openstreetmap.org/reverse?${params}`;
 
     fetch(nominatim_api_url_query)
         .then(response => {

--- a/js/main.js
+++ b/js/main.js
@@ -379,8 +379,7 @@ function createMap() {
                 .transform(this.map.getProjectionObject(), this.map.displayProjection);
 
             if (Object.keys(nominatim_data_global).length === 0) {
-                const nominatim_query = OpenLayers.String.format('&lat=${top}&lon=${left}', bbox);
-                this.updateNominatimData(nominatim_query);
+                this.updateNominatimData(bbox.top, bbox.left);
             }
 
             const bboxQuery = OpenLayers.String.format (
@@ -457,9 +456,9 @@ function createMap() {
 
         /* FIXME */
         // nominatim_data: {},
-        updateNominatimData: function (query) {
+        updateNominatimData: function (lat, lon) {
             reverseGeocodeLocation(
-                query,
+                lat, lon,
                 function(nominatim_data) {
                     // console.log(JSON.stringify(nominatim_data, null, '\t'));
                     /* http://stackoverflow.com/a/1144249 */
@@ -503,15 +502,22 @@ function createMap() {
                 this.createMarker (elementData);
             }
 
-            if (typeof elements[0] !== 'undefined' && (typeof this.lastLat === 'undefined'
-                || Math.abs(this.lastLat - elements[0].lat) > 2
-                || Math.abs(this.lastLon - elements[0].lon) > 2)) {
+            if (typeof elements[0] !== 'undefined') {
+                const firstElement = elements[0];
+                const firstLat = firstElement.center?.lat ?? firstElement.lat;
+                const firstLon = firstElement.center?.lon ?? firstElement.lon;
 
-                // console.log("updateNominatimData inside query");
-                this.updateNominatimData(`&osm_type=${elements[0].type.substr(0,1).toUpperCase()}&osm_id=${elements[0].id}`);
+                if (Number.isFinite(firstLat) && Number.isFinite(firstLon)
+                    && (typeof this.lastLat === 'undefined'
+                    || Math.abs(this.lastLat - firstLat) > 2
+                    || Math.abs(this.lastLon - firstLon) > 2)) {
 
-                this.lastLat = elements[0].lat;
-                this.lastLon = elements[0].lon;
+                    // Reverse geocode by coordinates to avoid stale/deleted OSM object IDs.
+                    this.updateNominatimData(firstLat, firstLon);
+
+                    this.lastLat = firstLat;
+                    this.lastLon = firstLon;
+                }
             }
         },
 


### PR DESCRIPTION
I noticed some 400 errors from Nominatim, so I dug into the reverse geocoding code.

The issue: we were looking up Overpass elements by osm_type/osm_id. This fails when an object exists in Overpass but is stale or unindexed in Nominatim.

Switched to lat/lon-based reverse geocoding instead. Much more reliable.

Also fixed a bug with ways and relations — the code couldn't detect when you'd panned to a new region, so regional data (holidays, etc.) wasn't fetched from Nominatim.

Cleaned up `reverseGeocodeLocation()` to take explicit lat/lon params instead of query strings.

Also updated the opening_hours.js submodule in a separate commit.