### PR TITLE
feat: introduce dev mode with mock overpass endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,14 +43,42 @@ The map uses OpenLayers to show a base map from OpenStreetMap. An additional opt
 
 ## Development
 
-The app is fully static. Serve `index.html` through any local HTTP server for
-development or open the hosted instance directly.
+### Local Development
 
-Overpass requests go directly to public fallback endpoints:
+Start the development server:
 
-- `https://overpass-api.de/api/interpreter`
-- `https://overpass.kumi.systems/api/interpreter`
-- `https://overpass.private.coffee/api/interpreter`
+```Shell
+npm run dev
+```
+
+This opens the app with `?mock=true` by default.
+
+Use the normal map URL parameters (`lat`, `lon`, `zoom`) to center the map on
+the mock region you want to work with.
+
+This starts Vite on `http://127.0.0.1:5502/` (or the next free port) and
+serves the app without a custom Overpass proxy.
+
+**Why Mock in Development?**
+
+Browser-direct calls to public Overpass endpoints often fail due to CORS and
+rate limits. Local mock data keeps development predictable and avoids noisy
+network failures.
+
+### Overpass Request Flow
+
+Default request order depends on runtime mode:
+
+1. Vite development mode (`npm run dev`):
+        - starts with `?mock=true` by default (local mock interpreter endpoint
+            `/api/mock/interpreter`, backed by `data/dev-overpass-sample.json`)
+        - use `lat=<...>&lon=<...>&zoom=<...>` to center the view on your target region
+        - remove `mock=true` to use direct browser requests to public Overpass
+            endpoints
+2. Production build:
+    - `https://overpass-api.de/api/interpreter`
+    - `https://overpass.kumi.systems/api/interpreter`
+    - `https://overpass.private.coffee/api/interpreter`
 
 Network/CORS failures trigger endpoint cooldown and a short global cooldown to
 avoid hammering endpoints.

--- a/data/dev-overpass-sample.json
+++ b/data/dev-overpass-sample.json
@@ -1,0 +1,666 @@
+{
+  "version": 0.6,
+  "generator": "opening_hours_map dev mock",
+  "elements": [
+    {
+      "type": "node",
+      "id": 9000001,
+      "lat": 50.729706,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 01",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Fr 10:00-20:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000002,
+      "lat": 50.729706,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 02",
+        "amenity": "cafe",
+        "opening_hours": "Mo,Tu,Th,Fr 12:00-18:00; Sa,PH 12:00-17:00; Th[3],Th[-1] off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000003,
+      "lat": 50.729706,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 03",
+        "amenity": "cafe",
+        "opening_hours": "00:00-24:00; Tu-Su,PH 08:30-09:00 off; Tu-Su 14:00-14:30 off; Mo 08:00-13:00 off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000004,
+      "lat": 50.729706,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 04",
+        "amenity": "cafe",
+        "opening_hours": "Fr-Sa 18:00-06:00; PH 18:00-06:00 off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000005,
+      "lat": 50.729706,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 05",
+        "amenity": "cafe",
+        "opening_hours": "Mo 10:00-12:00,12:30-15:00"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000006,
+      "lat": 50.729706,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 06",
+        "amenity": "cafe",
+        "opening_hours": "Mo 10:00-12:00,12:30-15:00; Tu-Fr 08:00-12:00,12:30-15:00; Sa 08:00-12:00"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000007,
+      "lat": 50.729706,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 07",
+        "amenity": "cafe",
+        "opening_hours": "24/7"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000008,
+      "lat": 50.729706,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 08",
+        "amenity": "cafe",
+        "opening_hours": "\"only after registration\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000009,
+      "lat": 50.731919,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 09",
+        "amenity": "cafe",
+        "opening_hours": "22:00-23:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000010,
+      "lat": 50.731919,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 10",
+        "amenity": "cafe",
+        "opening_hours": "08:00-11:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000011,
+      "lat": 50.731919,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 11",
+        "amenity": "cafe",
+        "opening_hours": "open; Mo 15:00-16:00 off; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000012,
+      "lat": 50.731919,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 12",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Su 22:00-23:00; We,PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000013,
+      "lat": 50.731919,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 13",
+        "amenity": "cafe",
+        "opening_hours": "We-Fr 10:00-24:00 open \"it is open\" || \"please call\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000014,
+      "lat": 50.731919,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 14",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Fr 08:00-11:00 || Tu-Th,PH open \"Emergency only\""
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000015,
+      "lat": 50.731919,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 15",
+        "amenity": "cafe",
+        "opening_hours": "Tu-Th,We 22:00-23:00 open \"Hot meals\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000016,
+      "lat": 50.731919,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 16",
+        "amenity": "cafe",
+        "opening_hours": "Mo 12:00-14:00 open \"female only\", Mo 14:00-16:00 open \"male only\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000017,
+      "lat": 50.734131,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 17",
+        "amenity": "cafe",
+        "opening_hours": "Apr: 22:00-23:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000018,
+      "lat": 50.734131,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 18",
+        "amenity": "cafe",
+        "opening_hours": "Jul-Jan: 22:00-23:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000019,
+      "lat": 50.734131,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 19",
+        "amenity": "cafe",
+        "opening_hours": "Jan-Jul: 22:00-23:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000020,
+      "lat": 50.734131,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 20",
+        "amenity": "cafe",
+        "opening_hours": "Jul 23-Jan 3: \"needs reservation by phone\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000021,
+      "lat": 50.734131,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 21",
+        "amenity": "cafe",
+        "opening_hours": "Jul 23-Jan 3: 22:00-23:00 \"Please make a reservation by phone.\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000022,
+      "lat": 50.734131,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 22",
+        "amenity": "cafe",
+        "opening_hours": "Jul 23-Jan 3: 08:00-11:00 \"Please make a reservation by phone.\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000023,
+      "lat": 50.734131,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 23",
+        "amenity": "cafe",
+        "opening_hours": "Jan 23-Jul 3: 22:00-23:00 \"Please make a reservation by phone.\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000024,
+      "lat": 50.734131,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 24",
+        "amenity": "cafe",
+        "opening_hours": "Mar Su[-1]-Dec Su[1] -2 days: 22:00-23:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000025,
+      "lat": 50.736344,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 25",
+        "amenity": "cafe",
+        "opening_hours": "Sa[1],Sa[1] +1 day 10:00-12:00 open \"first weekend in the month\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000026,
+      "lat": 50.736344,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 26",
+        "amenity": "cafe",
+        "opening_hours": "Sa[-1],Sa[-1] +1 day 10:00-12:00 open \"last weekend in the month\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000027,
+      "lat": 50.736344,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 27",
+        "amenity": "cafe",
+        "opening_hours": "Sa-Su 00:00-24:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000028,
+      "lat": 50.736344,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 28",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Fr 00:00-24:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000029,
+      "lat": 50.736344,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 29",
+        "amenity": "cafe",
+        "opening_hours": "sunrise-sunset open \"Beware of sunburn!\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000030,
+      "lat": 50.736344,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 30",
+        "amenity": "cafe",
+        "opening_hours": "sunset-sunrise open \"Beware of vampires!\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000031,
+      "lat": 50.736344,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 31",
+        "amenity": "cafe",
+        "opening_hours": "(sunset+01:00)-24:00 || closed \"No drink before sunset!\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000032,
+      "lat": 50.736344,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 32",
+        "amenity": "cafe",
+        "opening_hours": "22:00+; PH 22:00-12:00 off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000033,
+      "lat": 50.738556,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 33",
+        "amenity": "cafe",
+        "opening_hours": "Tu,PH 23:59-22:59"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000034,
+      "lat": 50.738556,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 34",
+        "amenity": "cafe",
+        "opening_hours": "We-Mo,PH 23:59-22:59"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000035,
+      "lat": 50.738556,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 35",
+        "amenity": "cafe",
+        "opening_hours": "week 2-52/2 We 00:00-24:00; week 1-53/2 Sa 00:00-24:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000036,
+      "lat": 50.738556,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 36",
+        "amenity": "cafe",
+        "opening_hours": "week 4-16 We 00:00-24:00; week 38-42 Sa 00:00-24:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000037,
+      "lat": 50.738556,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 37",
+        "amenity": "cafe",
+        "opening_hours": "2012 easter -2 days-2012 easter +2 days: open \"Around easter\"; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000038,
+      "lat": 50.738556,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 38",
+        "amenity": "cafe",
+        "opening_hours": "24/7 closed \"always closed\""
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000039,
+      "lat": 50.738556,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 39",
+        "amenity": "cafe",
+        "opening_hours": "2013,2015,2050-2053,2055/2,2020-2029/3,2060+ Jan 1"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000040,
+      "lat": 50.738556,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 40",
+        "amenity": "cafe",
+        "opening_hours": "Jan 23-Feb 11,Feb 12 00:00-24:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000041,
+      "lat": 50.740769,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 41",
+        "amenity": "cafe",
+        "opening_hours": "Apr-Oct Su[2] 14:00-18:00; Aug Su[-1] -1 day 10:00-18:00; Aug Su[-1] 10:00-18:00; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000042,
+      "lat": 50.740769,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 42",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Fr 08:00-12:00, We 14:00-18:00; Su,PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000043,
+      "lat": 50.740769,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 43",
+        "amenity": "cafe",
+        "opening_hours": "00:00-24:00 week 6 Mo-Su Feb; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000044,
+      "lat": 50.740769,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 44",
+        "amenity": "cafe",
+        "opening_hours": "monday, Tu, wE, TH 12:00 - 20:00 ; 14:00-16:00 Off ; closed public Holiday"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000045,
+      "lat": 50.740769,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 45",
+        "amenity": "cafe",
+        "opening_hours": "We; PH off"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000046,
+      "lat": 50.740769,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 46",
+        "amenity": "cafe",
+        "opening_hours": "PH"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000047,
+      "lat": 50.740769,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 47",
+        "amenity": "cafe",
+        "opening_hours": "PH Mo-Fr"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000048,
+      "lat": 50.740769,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 48",
+        "amenity": "cafe",
+        "opening_hours": "PH -1 day"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000049,
+      "lat": 50.742981,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 49",
+        "amenity": "cafe",
+        "opening_hours": "SH"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000050,
+      "lat": 50.742981,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 50",
+        "amenity": "cafe",
+        "opening_hours": "SH,PH"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000051,
+      "lat": 50.742981,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 51",
+        "amenity": "cafe",
+        "opening_hours": "PH,SH"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000052,
+      "lat": 50.742981,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 52",
+        "amenity": "cafe",
+        "opening_hours": "We[1-3]"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000053,
+      "lat": 50.742981,
+      "lon": 7.110544,
+      "tags": {
+        "name": "Mock Example 53",
+        "amenity": "cafe",
+        "opening_hours": "We[3-5]"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000054,
+      "lat": 50.742981,
+      "lon": 7.112731,
+      "tags": {
+        "name": "Mock Example 54",
+        "amenity": "cafe",
+        "opening_hours": "Sa"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000055,
+      "lat": 50.742981,
+      "lon": 7.114919,
+      "tags": {
+        "name": "Mock Example 55",
+        "amenity": "cafe",
+        "opening_hours": "Sa[1]"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000056,
+      "lat": 50.742981,
+      "lon": 7.117106,
+      "tags": {
+        "name": "Mock Example 56",
+        "amenity": "cafe",
+        "opening_hours": "Sa[1-3]"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000057,
+      "lat": 50.745194,
+      "lon": 7.101794,
+      "tags": {
+        "name": "Mock Example 57",
+        "amenity": "cafe",
+        "opening_hours": "Tu-Th"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000058,
+      "lat": 50.745194,
+      "lon": 7.103981,
+      "tags": {
+        "name": "Mock Example 58",
+        "amenity": "cafe",
+        "opening_hours": "Fr-Mo"
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000059,
+      "lat": 50.745194,
+      "lon": 7.106169,
+      "tags": {
+        "name": "Mock Example 59",
+        "amenity": "cafe",
+        "opening_hours": "Mo-Su; We \"only after registration\""
+      }
+    },
+    {
+      "type": "node",
+      "id": 9000060,
+      "lat": 50.745194,
+      "lon": 7.108356,
+      "tags": {
+        "name": "Mock Example 60",
+        "amenity": "cafe",
+        "opening_hours": "Oct: We[1]"
+      }
+    }
+  ]
+}

--- a/js/map-initial-state.js
+++ b/js/map-initial-state.js
@@ -85,8 +85,10 @@ export function createMapInitialState(options) {
 
     const initialUrlState = parseUrlState(search, fallbackTagByMode);
     const filterState = createFilterState(search);
+    const mockParam = params.get('mock');
     const permalinkParams = createPermalinkParams({
         filter: filterState.filter,
+        ...(typeof mockParam === 'string' ? {mock: mockParam} : {}),
     });
 
     return {

--- a/js/map-permalink-view-controller.js
+++ b/js/map-permalink-view-controller.js
@@ -75,6 +75,10 @@ function createPermalinkQueryParams(map, view, permalinkParams) {
         params.set('tags', permalinkParams.tags);
     }
 
+    if (permalinkParams && typeof permalinkParams.mock === 'string' && permalinkParams.mock.length > 0) {
+        params.set('mock', permalinkParams.mock);
+    }
+
     if (map && map.getView && map.getView().getRotation && Number.isFinite(map.getView().getRotation())) {
         const rotation = map.getView().getRotation();
         if (rotation !== 0) {

--- a/js/overpass-query.js
+++ b/js/overpass-query.js
@@ -8,14 +8,37 @@ const REMOTE_OVERPASS_ENDPOINTS = [
     'https://overpass.private.coffee/api/interpreter',
 ];
 
-const DEFAULT_OVERPASS_ENDPOINTS = REMOTE_OVERPASS_ENDPOINTS;
+const DEFAULT_OVERPASS_ENDPOINTS = [...REMOTE_OVERPASS_ENDPOINTS];
 
 const GLOBAL_RATE_LIMIT_BACKOFF_MS = 30000;
 const ENDPOINT_NETWORK_BACKOFF_MS = 15000;
+const DEV_OVERPASS_MOCK_ENDPOINT = '/api/mock/interpreter';
 
 let globalCooldownUntil = 0;
 let globalCooldownReason = 'failures';
 const endpointCooldownUntil = new Map();
+
+export function shouldUseDevMockOverpass(
+    locationSearch = globalThis?.location?.search,
+    isDevMode = Boolean(import.meta.env?.DEV)
+) {
+    if (!isDevMode) {
+        return false;
+    }
+
+    const params = new URLSearchParams(String(locationSearch || ''));
+    const mock = params.get('mock');
+
+    if (mock === 'true' || mock === '1') {
+        return true;
+    }
+
+    if (mock === 'false' || mock === '0') {
+        return false;
+    }
+
+    return false;
+}
 
 function getSecondsRemaining(until, now = Date.now()) {
     return Math.max(0, Math.ceil((until - now) / 1000));
@@ -255,7 +278,23 @@ export async function loadOverpassPois(overpassQl, options = {}) {
         timeoutMs = 30000,
         endpoints = DEFAULT_OVERPASS_ENDPOINTS,
         signal,
+        useMockOverpass = shouldUseDevMockOverpass(),
+        mockEndpoint = DEV_OVERPASS_MOCK_ENDPOINT,
     } = options;
+
+    if (useMockOverpass) {
+        const result = await fetchOverpassJsonWithFallback(overpassQl, {
+            timeoutMs,
+            endpoints: [mockEndpoint],
+            signal,
+        });
+
+        return {
+            data: result.data,
+            fallbackEndpoint: null,
+        };
+    }
+
     const result = await fetchOverpassJsonWithFallback(overpassQl, {
         timeoutMs,
         endpoints,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,42 @@
         "eslint": "^10.5.0",
         "globals": "^17.6.0",
         "html-validate": "^11.5.3",
-        "rollup": "^4.62.0"
+        "rollup": "^4.62.0",
+        "vite": "^8.1.5"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -225,10 +260,321 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@petamoriken/float16": {
       "version": "3.9.3",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.3.tgz",
       "integrity": "sha512-8awtpHXCx/bNpFt4mt2xdkgtgVvKqty8VbjHI/WWWQuEw+KLzFot3f4+LkQY9YmOtq7A5GdOnqoIC8Pdygjk2g==",
+      "license": "MIT"
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-node-resolve": {
@@ -689,6 +1035,17 @@
         "eslint": "^9.0.0 || ^10.0.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/esrecurse": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
@@ -858,6 +1215,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/earcut": {
@@ -1119,6 +1486,24 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fflate": {
       "version": "0.8.3",
@@ -1482,6 +1867,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -1520,6 +2178,25 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -1656,10 +2333,17 @@
         "pbf": "bin/pbf"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1667,6 +2351,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -1793,6 +2506,40 @@
         "protocol-buffers-schema": "^3.3.1"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.62.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
@@ -1881,6 +2628,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -1893,6 +2650,31 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -1924,6 +2706,84 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
       }
     },
     "node_modules/web-worker": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Interactive map showing opening_hours tags from OpenStreetMap",
   "scripts": {
     "build": "rollup -c",
+    "dev": "vite --open '/?mock=true&lat=50.7374&lon=7.1106&zoom=13'",
     "test": "npm run test:unit && npm run test:html && npm run lint",
     "test:unit": "node --test 'test/unit/**/*.test.js'",
     "test:html": "html-validate 'index.html'",
@@ -19,7 +20,8 @@
     "eslint": "^10.5.0",
     "globals": "^17.6.0",
     "html-validate": "^11.5.3",
-    "rollup": "^4.62.0"
+    "rollup": "^4.62.0",
+    "vite": "^8.1.5"
   },
   "repository": {
     "type": "git",

--- a/test/unit/core/overpass-query.test.js
+++ b/test/unit/core/overpass-query.test.js
@@ -60,7 +60,15 @@ test('overpass-query', async t => {
         const originalFetch = globalThis.fetch;
         let calls = 0;
 
-        globalThis.fetch = async () => {
+        globalThis.fetch = async (url) => {
+            if (String(url) === '/api/mock/interpreter') {
+                return {
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ elements: [{id: 999}] }),
+                };
+            }
+
             calls += 1;
             if (calls === 1) {
                 return {
@@ -86,6 +94,14 @@ test('overpass-query', async t => {
 
             assert.strictEqual(result.fallbackEndpoint, 'https://b.example/api');
             assert.deepStrictEqual(result.data, { elements: [] });
+
+            const mockResult = await loadOverpassPois('dummy-query', {
+                useMockOverpass: true,
+                mockEndpoint: '/api/mock/interpreter',
+            });
+
+            assert.strictEqual(mockResult.fallbackEndpoint, null);
+            assert.deepStrictEqual(mockResult.data, { elements: [{id: 999}] });
         } finally {
             globalThis.fetch = originalFetch;
         }
@@ -124,4 +140,5 @@ test('overpass-query', async t => {
             globalThis.location = originalLocation;
         }
     });
+
 });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,42 @@
+import {defineConfig} from 'vite';
+import {readFile} from 'node:fs/promises';
+
+const DEV_MOCK_OVERPASS_ENDPOINT = '/api/mock/interpreter';
+const DEV_MOCK_DATA_FILE = new URL('./data/dev-overpass-sample.json', import.meta.url);
+
+export default defineConfig({
+    server: {
+        host: '127.0.0.1',
+        port: 5502,
+        strictPort: false,
+    },
+    plugins: [
+        {
+            name: 'dev-overpass-mock-endpoint',
+            configureServer(server) {
+                server.middlewares.use(async (req, res, next) => {
+                    const path = String(req.url || '').split('?')[0];
+                    if (req.method !== 'POST' || path !== DEV_MOCK_OVERPASS_ENDPOINT) {
+                        return next();
+                    }
+
+                    try {
+                        const mockJson = await readFile(DEV_MOCK_DATA_FILE, 'utf8');
+                        res.statusCode = 200;
+                        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+                        res.end(mockJson);
+                    } catch (error) {
+                        res.statusCode = 500;
+                        res.setHeader('Content-Type', 'application/json; charset=utf-8');
+                        res.end(JSON.stringify({
+                            message: 'dev overpass mock unavailable',
+                            detail: String(error?.message || error || 'unknown error'),
+                        }));
+                    }
+
+                    return undefined;
+                });
+            },
+        },
+    ],
+});


### PR DESCRIPTION
During development, I keep running into CORS, 429, and timeout issues with the public Overpass servers, even when working on changes that do not require real requests. This makes development unnecessarily slow and frustrating.

My idea was to add a development script (`npm run dev`) that starts the map with local mock data. This allows the UI to be developed and tested reliably without depending on the availability or rate limits of the Overpass servers.
